### PR TITLE
Update best-of-mkdocs entry

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -78,7 +78,7 @@ projects:
     labels: ["javascript"]
     category: "web-dev"
   - name: best-of-mkdocs
-    github_id: pawamoy/best-of-mkdocs
+    github_id: mkdocs/catalog
     category: "documentation"
   - name: best-of-digital-gardens
     github_id: lyz-code/best-of-digital-gardens


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Add a project
- [x] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
The repo was moved into the `mkdocs` organization and renamed `catalog`. This commit updates the github_id for this project, but leaves the name as "best-of-mkdocs" for consistency within the readme.

See https://github.com/mkdocs/catalog/issues/91.

**Checklist:**
- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
