### PR TITLE
Add related repositories badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     <a href="#Contents" title="Project Count"><img src="https://img.shields.io/badge/projects-25-blue.svg?color=5ac4bf"></a>
     <a href="#Contribution" title="Contributions are welcome"><img src="https://img.shields.io/badge/contributions-welcome-green.svg"></a>
     <a href="https://github.com/best-of-lists/best-of/releases" title="Best-of Updates"><img src="https://img.shields.io/github/release-date/best-of-lists/best-of?color=green&label=updated"></a>
+	<a href="https://relatedrepos.com/gh/best-of-lists/best-of" title="Related to best-of-lists/best-of"><img src="https://img.shields.io/badge/related-repos-yellow"></a>
 </p>
 
 This curated list contains 25 best-of lists with a total of 42K stars grouped into 10 categories. All projects are ranked by a project-quality score, which is calculated based on various metrics automatically collected from Github and different package managers. If you like to add or update projects, feel free to open an [issue](https://github.com/best-of-lists/best-of/issues/new/choose), submit a [pull request](https://github.com/best-of-lists/best-of/pulls), or directly edit the [projects.yaml](https://github.com/best-of-lists/best-of/edit/main/projects.yaml). Contributions are very welcome!


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [x] Other, please describe:

**Description:**
Added a badge for related repositories to the README.

This helps your users to quickly discover repositories that are related to `best-of-lists/best-of`.

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [ ] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
