### PR TITLE
Add project: marketing-ai-stack

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -133,3 +133,5 @@ projects:
   - name: best-of-mcp-servers
     github_id: tolkonepiu/best-of-mcp-servers
     category: "data-engineering"
+  - name: marketing-ai-stack
+    github_id: dapollonsky/marketing-ai-stack


### PR DESCRIPTION
Adds dapollonsky/marketing-ai-stack to projects.yaml as an uncategorized best-of list, per the contribution guide's fallback for projects that do not fit the existing categories.